### PR TITLE
Slim down CI runner

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install python dependencies
-        run: python3 -m pip install -r requirements.txt
+        run: python3 -m pip install --verbose --progress-bar 'off' --requirement requirements.txt
 
       - name: Build with site-generator.py
         run: python3 site-generator.py

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-and-deploy-website:
-    name: Build and Deploy Website
+    name: Build and deploy website
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -20,8 +20,8 @@ concurrency:
 jobs:
   build-and-deploy-website:
     name: Build and deploy website
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The main change is to use the new `ubuntu-slim` runner. This is a single CPU hosted runner designed for short tasks. We don't need any significant compute, so it should be ideal, especially if it has lower startup latency.

The job timeout has also been reduced. Given the site builds locally in ~0.25 seconds, 5 minutes of CI time should be plenty.

Finally, some cosmetic tweaks to CI logs have been made.