### PR TITLE
Move to monthly Actions dependency updates and add cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,4 +9,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
We don't need super frequent updates, and a cooldown is a sensible idea.

https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns